### PR TITLE
Validate Multiple Values on Object and Missing Validation in Controller.

### DIFF
--- a/src/main/factories/controllers/login/login/login-validation-factory.spec.ts
+++ b/src/main/factories/controllers/login/login/login-validation-factory.spec.ts
@@ -20,14 +20,10 @@ const makeEmailValidator = (): EmailValidator => {
 
 describe("LoginValidation Factory", () => {
   test("Should call ValidationComposite with all validations", () => {
-    // Execute function that return ValidationComposite module
     makeLoginValidation();
     const validations: Validation[] = [];
-    for (const field of ["email", "password"]) {
-      validations.push(new RequiredFieldValidation(field));
-    }
+    validations.push(new RequiredFieldValidation(["email", "password"]));
     validations.push(new EmailValidation("email", makeEmailValidator()));
-    // Expect that ValidationComposite module to have called
     expect(ValidationComposite).toHaveBeenCalledWith(validations);
   });
 });

--- a/src/main/factories/controllers/login/login/login-validation-factory.ts
+++ b/src/main/factories/controllers/login/login/login-validation-factory.ts
@@ -8,9 +8,7 @@ import {
 
 export const makeLoginValidation = (): ValidationComposite => {
   const validations: Validation[] = [];
-  for (const field of ["email", "password"]) {
-    validations.push(new RequiredFieldValidation(field));
-  }
+  validations.push(new RequiredFieldValidation(["email", "password"]));
   validations.push(new EmailValidation("email", new EmailValidatorAdapter()));
   return new ValidationComposite(validations);
 };

--- a/src/main/factories/controllers/login/signup/signup-validation-factory.spec.ts
+++ b/src/main/factories/controllers/login/signup/signup-validation-factory.spec.ts
@@ -21,17 +21,20 @@ const makeEmailValidator = (): EmailValidator => {
 
 describe("SignUpValidation Factory", () => {
   test("Should call ValidationComposite with all validations", () => {
-    // Execute function that return ValidationComposite module
     makeSignUpValidation();
     const validations: Validation[] = [];
-    for (const field of ["name", "email", "password", "passwordConfirmation"]) {
-      validations.push(new RequiredFieldValidation(field));
-    }
+    validations.push(
+      new RequiredFieldValidation([
+        "name",
+        "email",
+        "password",
+        "passwordConfirmation",
+      ])
+    );
     validations.push(
       new CompareFieldsValidation("password", "passwordConfirmation")
     );
     validations.push(new EmailValidation("email", makeEmailValidator()));
-    // Expect that ValidationComposite module to have called
     expect(ValidationComposite).toHaveBeenCalledWith(validations);
   });
 });

--- a/src/main/factories/controllers/login/signup/signup-validation-factory.ts
+++ b/src/main/factories/controllers/login/signup/signup-validation-factory.ts
@@ -9,9 +9,14 @@ import {
 
 export const makeSignUpValidation = (): ValidationComposite => {
   const validations: Validation[] = [];
-  for (const field of ["name", "email", "password", "passwordConfirmation"]) {
-    validations.push(new RequiredFieldValidation(field));
-  }
+  validations.push(
+    new RequiredFieldValidation([
+      "name",
+      "email",
+      "password",
+      "passwordConfirmation",
+    ])
+  );
   validations.push(
     new CompareFieldsValidation("password", "passwordConfirmation")
   );

--- a/src/main/factories/controllers/survey-result/save-survey-result/save-survey-result-controller-factory.ts
+++ b/src/main/factories/controllers/survey-result/save-survey-result/save-survey-result-controller-factory.ts
@@ -3,9 +3,11 @@ import { makeDbSaveSurveyResult } from "@/main/factories/usecases/survey-result/
 import { makeDbLoadSurveyById } from "@/main/factories/usecases/survey/load-survey-by-id/db-load-survey-by-id-factory";
 import { SaveSurveyResultController } from "@/presentation/controllers/survey-result/save-survey-result/save-survey-result-controller";
 import { Controller } from "@/presentation/protocols";
+import { makeSaveSurveyResultValidation } from "./save-survey-result-validation-factory";
 
 export const makeSaveSurveyResultController = (): Controller => {
   const controller = new SaveSurveyResultController(
+    makeSaveSurveyResultValidation(),
     makeDbLoadSurveyById(),
     makeDbSaveSurveyResult()
   );

--- a/src/main/factories/controllers/survey-result/save-survey-result/save-survey-result-validation-factory.spec.ts
+++ b/src/main/factories/controllers/survey-result/save-survey-result/save-survey-result-validation-factory.spec.ts
@@ -1,0 +1,17 @@
+import { Validation } from "@/presentation/protocols/validation";
+import {
+  RequiredFieldValidation,
+  ValidationComposite,
+} from "@/validation/validators";
+import { makeSaveSurveyResultValidation } from "./save-survey-result-validation-factory";
+
+jest.mock("@/validation/validators/validation-composite");
+
+describe("SaveSurveyResultValidation Factory", () => {
+  test("Should call ValidationComposite with all validations", () => {
+    makeSaveSurveyResultValidation();
+    const validations: Validation[] = [];
+    validations.push(new RequiredFieldValidation(["answer"]));
+    expect(ValidationComposite).toHaveBeenCalledWith(validations);
+  });
+});

--- a/src/main/factories/controllers/survey-result/save-survey-result/save-survey-result-validation-factory.ts
+++ b/src/main/factories/controllers/survey-result/save-survey-result/save-survey-result-validation-factory.ts
@@ -1,0 +1,11 @@
+import { Validation } from "@/presentation/protocols";
+import {
+  RequiredFieldValidation,
+  ValidationComposite,
+} from "@/validation/validators";
+
+export const makeSaveSurveyResultValidation = (): Validation => {
+  const validations: Validation[] = [];
+  validations.push(new RequiredFieldValidation(["answer"]));
+  return new ValidationComposite(validations);
+};

--- a/src/main/factories/controllers/survey/add-survey/add-survey-validation-factory.spec.ts
+++ b/src/main/factories/controllers/survey/add-survey/add-survey-validation-factory.spec.ts
@@ -11,9 +11,7 @@ describe("AddSurveyValidation Factory", () => {
   test("Should call ValidationComposite with all validations", () => {
     makeAddSurveyValidation();
     const validations: Validation[] = [];
-    for (const field of ["question", "answers"]) {
-      validations.push(new RequiredFieldValidation(field));
-    }
+    validations.push(new RequiredFieldValidation(["question", "answers"]));
     expect(ValidationComposite).toHaveBeenCalledWith(validations);
   });
 });

--- a/src/main/factories/controllers/survey/add-survey/add-survey-validation-factory.spec.ts
+++ b/src/main/factories/controllers/survey/add-survey/add-survey-validation-factory.spec.ts
@@ -1,5 +1,6 @@
 import { Validation } from "@/presentation/protocols/validation";
 import {
+  MultipleValuesValidation,
   RequiredFieldValidation,
   ValidationComposite,
 } from "@/validation/validators";
@@ -12,6 +13,11 @@ describe("AddSurveyValidation Factory", () => {
     makeAddSurveyValidation();
     const validations: Validation[] = [];
     validations.push(new RequiredFieldValidation(["question", "answers"]));
+    validations.push(
+      new MultipleValuesValidation("answers", [
+        new RequiredFieldValidation(["answer"]),
+      ])
+    );
     expect(ValidationComposite).toHaveBeenCalledWith(validations);
   });
 });

--- a/src/main/factories/controllers/survey/add-survey/add-survey-validation-factory.ts
+++ b/src/main/factories/controllers/survey/add-survey/add-survey-validation-factory.ts
@@ -6,8 +6,6 @@ import {
 
 export const makeAddSurveyValidation = (): ValidationComposite => {
   const validations: Validation[] = [];
-  for (const field of ["question", "answers"]) {
-    validations.push(new RequiredFieldValidation(field));
-  }
+  validations.push(new RequiredFieldValidation(["question", "answers"]));
   return new ValidationComposite(validations);
 };

--- a/src/main/factories/controllers/survey/add-survey/add-survey-validation-factory.ts
+++ b/src/main/factories/controllers/survey/add-survey/add-survey-validation-factory.ts
@@ -2,10 +2,16 @@ import { Validation } from "@/presentation/protocols/validation";
 import {
   ValidationComposite,
   RequiredFieldValidation,
+  MultipleValuesValidation,
 } from "@/validation/validators";
 
 export const makeAddSurveyValidation = (): ValidationComposite => {
   const validations: Validation[] = [];
   validations.push(new RequiredFieldValidation(["question", "answers"]));
+  validations.push(
+    new MultipleValuesValidation("answers", [
+      new RequiredFieldValidation(["answer"]),
+    ])
+  );
   return new ValidationComposite(validations);
 };

--- a/src/presentation/controllers/survey-result/save-survey-result/save-survey-result-controller.spec.ts
+++ b/src/presentation/controllers/survey-result/save-survey-result/save-survey-result-controller.spec.ts
@@ -11,6 +11,7 @@ import {
   SurveyResultModel,
   ok,
   Validation,
+  badRequest,
 } from "./save-survey-result-controller-protocols";
 import MockDate from "mockdate";
 
@@ -101,6 +102,13 @@ describe("SaveSurveyResult Controller", () => {
     const httpRequest = makeFakeRequest();
     await sut.handle(httpRequest);
     expect(validateSpy).toHaveBeenCalledWith(httpRequest.body);
+  });
+
+  test("Should return 400 if Validation fails", async () => {
+    const { sut, validationStub } = makeSut();
+    jest.spyOn(validationStub, "validate").mockReturnValueOnce(new Error());
+    const httpResponse = await sut.handle(makeFakeRequest());
+    expect(httpResponse).toEqual(badRequest(new Error()));
   });
 
   test("Should call LoadSurveyById with correct values", async () => {

--- a/src/presentation/controllers/survey-result/save-survey-result/save-survey-result-controller.ts
+++ b/src/presentation/controllers/survey-result/save-survey-result/save-survey-result-controller.ts
@@ -9,6 +9,7 @@ import {
   SaveSurveyResult,
   ok,
   Validation,
+  badRequest,
 } from "./save-survey-result-controller-protocols";
 
 export class SaveSurveyResultController implements Controller {
@@ -20,7 +21,10 @@ export class SaveSurveyResultController implements Controller {
 
   async handle(httpRequest: HttpRequest): Promise<HttpResponse> {
     try {
-      this.validation.validate(httpRequest.body);
+      const error = this.validation.validate(httpRequest.body);
+      if (error) {
+        return badRequest(error);
+      }
 
       const surveyId = httpRequest.params?.surveyId;
       const surveyAnswer = httpRequest.body?.answer;

--- a/src/presentation/controllers/survey-result/save-survey-result/save-survey-result-controller.ts
+++ b/src/presentation/controllers/survey-result/save-survey-result/save-survey-result-controller.ts
@@ -8,16 +8,20 @@ import {
   serverError,
   SaveSurveyResult,
   ok,
+  Validation,
 } from "./save-survey-result-controller-protocols";
 
 export class SaveSurveyResultController implements Controller {
   constructor(
+    private readonly validation: Validation,
     private readonly loadSurveyById: LoadSurveyById,
     private readonly saveSurveyResult: SaveSurveyResult
   ) {}
 
   async handle(httpRequest: HttpRequest): Promise<HttpResponse> {
     try {
+      this.validation.validate(httpRequest.body);
+
       const surveyId = httpRequest.params?.surveyId;
       const surveyAnswer = httpRequest.body?.answer;
 

--- a/src/validation/validators/index.ts
+++ b/src/validation/validators/index.ts
@@ -2,3 +2,4 @@ export * from "./compare-fields-validation";
 export * from "./email-validation";
 export * from "./required-field-validation";
 export * from "./validation-composite";
+export * from "./multiple-values-validation";

--- a/src/validation/validators/multiple-values-validation.spec.ts
+++ b/src/validation/validators/multiple-values-validation.spec.ts
@@ -2,39 +2,41 @@ import { MissingParamError } from "@/presentation/errors/missing-param-error";
 import { Validation } from "@/presentation/protocols";
 import { MultipleValuesValidation } from "./multiple-values-validation";
 
+const makeValidation = (): Validation => {
+  class ValidationStub implements Validation {
+    validate(input: any): Error | null {
+      return null;
+    }
+  }
+  return new ValidationStub();
+};
+
+type SutTypes = {
+  sut: MultipleValuesValidation;
+  validationStub: Validation;
+};
+
+const makeSut = (): SutTypes => {
+  const validationStub = makeValidation();
+  const sut = new MultipleValuesValidation("objectFieldName", [validationStub]);
+  return { sut, validationStub };
+};
+
 describe("Multiple Values Validation", () => {
   test("Should return a MissingParamError if objectFieldName validation fails", () => {
-    class ValidationStub implements Validation {
-      constructor(private readonly fieldNames: string[]) {}
-      validate(input: any): Error | null {
-        return null;
-      }
-    }
-    const validationStub = new ValidationStub(["field"]);
+    const { sut, validationStub } = makeSut();
     jest
       .spyOn(validationStub, "validate")
       .mockReturnValueOnce(new MissingParamError("objectFieldName"));
-    const sut = new MultipleValuesValidation("objectFieldName", [
-      validationStub,
-    ]);
     const error = sut.validate({ invalidField: [{ field: "any_value" }] });
     expect(error).toEqual(new MissingParamError("objectFieldName"));
   });
 
   test("Should return a MissingParamError if fieldNames validation fails", () => {
-    class ValidationStub implements Validation {
-      constructor(private readonly fieldNames: string[]) {}
-      validate(input: any): Error | null {
-        return null;
-      }
-    }
-    const validationStub = new ValidationStub(["field"]);
+    const { sut, validationStub } = makeSut();
     jest
       .spyOn(validationStub, "validate")
       .mockReturnValueOnce(new MissingParamError("field"));
-    const sut = new MultipleValuesValidation("objectFieldName", [
-      validationStub,
-    ]);
     const error = sut.validate({
       objectFieldName: [{ invalidField: "any_value" }],
     });

--- a/src/validation/validators/multiple-values-validation.spec.ts
+++ b/src/validation/validators/multiple-values-validation.spec.ts
@@ -3,7 +3,7 @@ import { Validation } from "@/presentation/protocols";
 import { MultipleValuesValidation } from "./multiple-values-validation";
 
 describe("Multiple Values Validation", () => {
-  test("Should return a MissingParamError if object fieldname validation fails", () => {
+  test("Should return a MissingParamError if objectFieldName validation fails", () => {
     class ValidationStub implements Validation {
       constructor(private readonly fieldNames: string[]) {}
       validate(input: any): Error | null {
@@ -19,5 +19,25 @@ describe("Multiple Values Validation", () => {
     ]);
     const error = sut.validate({ invalidField: [{ field: "any_value" }] });
     expect(error).toEqual(new MissingParamError("objectFieldName"));
+  });
+
+  test("Should return a MissingParamError if fieldNames validation fails", () => {
+    class ValidationStub implements Validation {
+      constructor(private readonly fieldNames: string[]) {}
+      validate(input: any): Error | null {
+        return null;
+      }
+    }
+    const validationStub = new ValidationStub(["field"]);
+    jest
+      .spyOn(validationStub, "validate")
+      .mockReturnValueOnce(new MissingParamError("field"));
+    const sut = new MultipleValuesValidation("objectFieldName", [
+      validationStub,
+    ]);
+    const error = sut.validate({
+      objectFieldName: [{ invalidField: "any_value" }],
+    });
+    expect(error).toEqual(new MissingParamError("field"));
   });
 });

--- a/src/validation/validators/multiple-values-validation.spec.ts
+++ b/src/validation/validators/multiple-values-validation.spec.ts
@@ -42,4 +42,12 @@ describe("Multiple Values Validation", () => {
     });
     expect(error).toEqual(new MissingParamError("field"));
   });
+
+  test("Should not return if validation succeds", () => {
+    const { sut } = makeSut();
+    const error = sut.validate({
+      objectFieldName: [{ field: "any_value" }],
+    });
+    expect(error).toBeNull();
+  });
 });

--- a/src/validation/validators/multiple-values-validation.spec.ts
+++ b/src/validation/validators/multiple-values-validation.spec.ts
@@ -1,0 +1,23 @@
+import { MissingParamError } from "@/presentation/errors/missing-param-error";
+import { Validation } from "@/presentation/protocols";
+import { MultipleValuesValidation } from "./multiple-values-validation";
+
+describe("Multiple Values Validation", () => {
+  test("Should return a MissingParamError if object fieldname validation fails", () => {
+    class ValidationStub implements Validation {
+      constructor(private readonly fieldNames: string[]) {}
+      validate(input: any): Error | null {
+        return null;
+      }
+    }
+    const validationStub = new ValidationStub(["field"]);
+    jest
+      .spyOn(validationStub, "validate")
+      .mockReturnValueOnce(new MissingParamError("objectFieldName"));
+    const sut = new MultipleValuesValidation("objectFieldName", [
+      validationStub,
+    ]);
+    const error = sut.validate({ invalidField: [{ field: "any_value" }] });
+    expect(error).toEqual(new MissingParamError("objectFieldName"));
+  });
+});

--- a/src/validation/validators/multiple-values-validation.ts
+++ b/src/validation/validators/multiple-values-validation.ts
@@ -11,6 +11,15 @@ export class MultipleValuesValidation implements Validation {
     if (!input[this.objectFieldName]) {
       return new MissingParamError(this.objectFieldName);
     }
+
+    for (const validation of this.validations) {
+      for (const fieldName in input[this.objectFieldName]) {
+        const error = validation.validate(fieldName);
+        if (error) {
+          return error;
+        }
+      }
+    }
     return null;
   }
 }

--- a/src/validation/validators/multiple-values-validation.ts
+++ b/src/validation/validators/multiple-values-validation.ts
@@ -13,7 +13,7 @@ export class MultipleValuesValidation implements Validation {
     }
 
     for (const validation of this.validations) {
-      for (const fieldName in input[this.objectFieldName]) {
+      for (const fieldName of input[this.objectFieldName]) {
         const error = validation.validate(fieldName);
         if (error) {
           return error;

--- a/src/validation/validators/multiple-values-validation.ts
+++ b/src/validation/validators/multiple-values-validation.ts
@@ -1,0 +1,16 @@
+import { MissingParamError } from "@/presentation/errors";
+import { Validation } from "@/presentation/protocols";
+
+export class MultipleValuesValidation implements Validation {
+  constructor(
+    private readonly objectFieldName: string,
+    private readonly validations: Validation[]
+  ) {}
+
+  validate(input: any): Error | null {
+    if (!input[this.objectFieldName]) {
+      return new MissingParamError(this.objectFieldName);
+    }
+    return null;
+  }
+}

--- a/src/validation/validators/required-field-validation.spec.ts
+++ b/src/validation/validators/required-field-validation.spec.ts
@@ -2,7 +2,7 @@ import { MissingParamError } from "@/presentation/errors";
 import { RequiredFieldValidation } from "./required-field-validation";
 
 const makeSut = (): RequiredFieldValidation =>
-  new RequiredFieldValidation("field");
+  new RequiredFieldValidation(["field"]);
 
 describe("Required Field Validation", () => {
   test("Should return a MissingParamError if validation fails", () => {

--- a/src/validation/validators/required-field-validation.ts
+++ b/src/validation/validators/required-field-validation.ts
@@ -2,11 +2,13 @@ import { Validation } from "@/presentation/protocols";
 import { MissingParamError } from "@/presentation/errors";
 
 export class RequiredFieldValidation implements Validation {
-  constructor(private readonly fieldName: string) {}
+  constructor(private readonly fieldNames: string[]) {}
 
   validate(input: any): Error | null {
-    if (!input[this.fieldName]) {
-      return new MissingParamError(this.fieldName);
+    for (const fieldName of this.fieldNames) {
+      if (!input[fieldName]) {
+        return new MissingParamError(fieldName);
+      }
     }
     return null;
   }


### PR DESCRIPTION
### Validate Multiple Values on Object

Currently the API does not support the validation of multiple values ​​within an object. Its validation method only validates by object key, but not by multiple values, that is, objects within array objects. It is necessary to find some solution to this problem.

### Change the method of validating required fields

Currently the API is valid one field at a time, this currently handles perfectly with what we have. However, it would be good to do a validation of several fields at once, instead of one. This would make us avoid unnecessary processing in the main layer.