### PR TITLE
Add id to identify each answers a survey answer

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-lint-staged
+node_modules/.bin/lint-staged

--- a/src/data/protocols/db/survey/add-survey-repository.ts
+++ b/src/data/protocols/db/survey/add-survey-repository.ts
@@ -1,4 +1,4 @@
-import { AddSurveyModel } from "@/domain/usecases/survey/add-survey";
+import { AddSurveyModel } from "@/domain/models/survey";
 
 export interface AddSurveyRepository {
   add(surveyData: AddSurveyModel): Promise<void>;

--- a/src/data/usecases/survey-result/save-survey-result/db-save-survey-result.spec.ts
+++ b/src/data/usecases/survey-result/save-survey-result/db-save-survey-result.spec.ts
@@ -9,7 +9,7 @@ import MockDate from "mockdate";
 const makeFakeSurveyResultData = (): SaveSurveyResultModel => ({
   accountId: "any_account_id",
   surveyId: "any_survey_id",
-  answer: "any_answer",
+  answerId: "any_answer_id",
   date: new Date(),
 });
 

--- a/src/data/usecases/survey/add-survey/db-add-survey-protocols.ts
+++ b/src/data/usecases/survey/add-survey/db-add-survey-protocols.ts
@@ -1,2 +1,3 @@
+export * from "@/domain/models/survey";
 export * from "@/domain/usecases/survey/add-survey";
 export * from "@/data/protocols/db/survey/add-survey-repository";

--- a/src/data/usecases/survey/load-survey-by-id/db-load-survey-by-id.spec.ts
+++ b/src/data/usecases/survey/load-survey-by-id/db-load-survey-by-id.spec.ts
@@ -5,11 +5,12 @@ import {
 } from "./db-load-survey-by-id-protocols";
 import MockDate from "mockdate";
 
-const makeFakeSurvey = (): SurveyModel => ({
+const makeFakeLoadedSurvey = (): SurveyModel => ({
   id: "any_id",
   question: "any_question",
   answers: [
     {
+      answerId: "any_answer_id",
       image: "any_image",
       answer: "any_answer",
     },
@@ -20,7 +21,7 @@ const makeFakeSurvey = (): SurveyModel => ({
 const makeLoadSurveyByIdRepository = (): LoadSurveyByIdRepository => {
   class LoadSurveyByIdRepositoryStub implements LoadSurveyByIdRepository {
     async loadById(id: string): Promise<SurveyModel | null> {
-      return new Promise((resolve) => resolve(makeFakeSurvey()));
+      return new Promise((resolve) => resolve(makeFakeLoadedSurvey()));
     }
   }
   return new LoadSurveyByIdRepositoryStub();
@@ -55,7 +56,7 @@ describe("DbLoadSurveyById Usecase", () => {
   test("Should return Survey on success", async () => {
     const { sut } = makeSut();
     const survey = await sut.loadById("any_id");
-    expect(survey).toEqual(makeFakeSurvey());
+    expect(survey).toEqual(makeFakeLoadedSurvey());
   });
 
   test("Should throw if LoadSurveyByIdRepository throws", async () => {

--- a/src/data/usecases/survey/load-surveys/db-load-surveys.spec.ts
+++ b/src/data/usecases/survey/load-surveys/db-load-surveys.spec.ts
@@ -5,12 +5,13 @@ import {
 import { DbLoadSurveys } from "./db-load-surveys";
 import MockDate from "mockdate";
 
-const makeFakeSurveys = (): SurveyModel[] => [
+const makeFakeLoadedSurveys = (): SurveyModel[] => [
   {
     id: "any_id",
     question: "any_question",
     answers: [
       {
+        answerId: "any_answer_id",
         image: "any_image",
         answer: "any_answer",
       },
@@ -22,6 +23,7 @@ const makeFakeSurveys = (): SurveyModel[] => [
     question: "other_question",
     answers: [
       {
+        answerId: "other_answer_id",
         image: "other_image",
         answer: "other_answer",
       },
@@ -33,7 +35,7 @@ const makeFakeSurveys = (): SurveyModel[] => [
 const makeLoadSurveysRepository = (): LoadSurveysRepository => {
   class LoadSurveysRepositoryStub implements LoadSurveysRepository {
     async loadAll(): Promise<SurveyModel[]> {
-      return new Promise((resolve) => resolve(makeFakeSurveys()));
+      return new Promise((resolve) => resolve(makeFakeLoadedSurveys()));
     }
   }
   return new LoadSurveysRepositoryStub();
@@ -68,7 +70,7 @@ describe("DbLoadSurveys Usecase", () => {
   test("Should return a list of survey on success", async () => {
     const { sut } = makeSut();
     const surveys = await sut.load();
-    expect(surveys).toEqual(makeFakeSurveys());
+    expect(surveys).toEqual(makeFakeLoadedSurveys());
   });
 
   test("Should throw if LoadSurveysRepository throws", async () => {

--- a/src/domain/models/survey-result.ts
+++ b/src/domain/models/survey-result.ts
@@ -2,6 +2,6 @@ export type SurveyResultModel = {
   id: string;
   surveyId: string;
   accountId: string;
-  answer: string;
+  answerId: string;
   date: Date;
 };

--- a/src/domain/models/survey.ts
+++ b/src/domain/models/survey.ts
@@ -6,6 +6,11 @@ export type SurveyModel = {
 };
 
 export type SurveyAnswerModel = {
-  image?: string;
+  answerId: string;
   answer: string;
+  image?: string;
+};
+
+export type AddSurveyModel = Omit<SurveyModel, "id" | "answers"> & {
+  answers: Array<Omit<SurveyAnswerModel, "answerId">>;
 };

--- a/src/domain/usecases/survey/add-survey.ts
+++ b/src/domain/usecases/survey/add-survey.ts
@@ -1,6 +1,4 @@
-import { SurveyAnswerModel, SurveyModel } from "@/domain/models/survey";
-
-export type AddSurveyModel = Omit<SurveyModel, "id">;
+import { AddSurveyModel } from "@/domain/models/survey";
 
 export interface AddSurvey {
   add(data: AddSurveyModel): Promise<void>;

--- a/src/infra/db/mongodb/account/account-mongo-repository.ts
+++ b/src/infra/db/mongodb/account/account-mongo-repository.ts
@@ -32,7 +32,7 @@ export class AccountMongoRepository
 
   async updateAccessToken(id: string, token: string): Promise<void> {
     const accountCollection = await MongoHelper.getCollection("accounts");
-    const accountId = MongoHelper.toObjectId(id);
+    const accountId = MongoHelper.objectId(id);
     await accountCollection.updateOne(
       { _id: accountId },
       { $set: { accessToken: token } }

--- a/src/infra/db/mongodb/helpers/mongodb-helper.ts
+++ b/src/infra/db/mongodb/helpers/mongodb-helper.ts
@@ -26,7 +26,7 @@ export const MongoHelper = {
     return Object.assign({}, collectionWithoutId, { id: _id });
   },
 
-  toObjectId: (id: string): ObjectId => new ObjectId(id),
+  objectId: (id?: string): ObjectId => new ObjectId(id),
 
   map: <T>(collections: any[]): T[] =>
     collections.map((collection) => MongoHelper.assign<T>(collection)),

--- a/src/infra/db/mongodb/survey-result/survey-result-mongo-repository.spec.ts
+++ b/src/infra/db/mongodb/survey-result/survey-result-mongo-repository.spec.ts
@@ -27,10 +27,12 @@ const makeSurvey = async (): Promise<SurveyModel> => {
     question: "any_question",
     answers: [
       {
+        answerId: "any_answer_id",
         image: "any_image",
         answer: "any_answer",
       },
       {
+        answerId: "any_answer_id",
         answer: "other_answer",
       },
     ],
@@ -71,12 +73,12 @@ describe("Survey Mongo Repository", () => {
       const surveyResult = await sut.save({
         surveyId: survey.id,
         accountId: account.id,
-        answer: survey.answers[0].answer,
+        answerId: survey.answers[0].answerId,
         date: new Date(),
       });
       expect(surveyResult).toBeTruthy();
       expect(surveyResult.id).toBeTruthy();
-      expect(surveyResult.answer).toBe(survey.answers[0].answer);
+      expect(surveyResult.answerId).toBe(survey.answers[0].answerId);
     });
 
     test("Should update survey result if its not new", async () => {
@@ -86,18 +88,18 @@ describe("Survey Mongo Repository", () => {
       const insertedSurveyResult = await surveyResultCollection.insertOne({
         surveyId: survey.id,
         accountId: account.id,
-        answer: survey.answers[0].answer,
+        answerId: survey.answers[0].answerId,
         date: new Date(),
       });
       const surveyResult = await sut.save({
         surveyId: survey.id,
         accountId: account.id,
-        answer: survey.answers[1].answer,
+        answerId: survey.answers[1].answerId,
         date: new Date(),
       });
       expect(surveyResult).toBeTruthy();
       expect(surveyResult.id).toEqual(insertedSurveyResult.insertedId);
-      expect(surveyResult.answer).toBe(survey.answers[1].answer);
+      expect(surveyResult.answerId).toBe(survey.answers[1].answerId);
     });
   });
 });

--- a/src/infra/db/mongodb/survey-result/survey-result-mongo-repository.ts
+++ b/src/infra/db/mongodb/survey-result/survey-result-mongo-repository.ts
@@ -17,7 +17,7 @@ export class SurveyResultMongoRepository implements SaveSurveyResultRepository {
       },
       {
         $set: {
-          answer: data.answer,
+          answerId: data.answerId,
           date: data.date,
         },
       },

--- a/src/infra/db/mongodb/survey/survey-mongo-repository-protocols.ts
+++ b/src/infra/db/mongodb/survey/survey-mongo-repository-protocols.ts
@@ -1,7 +1,5 @@
-export { AddSurveyModel } from "@/domain/usecases/survey/add-survey";
+export { AddSurveyModel } from "@/domain/models/survey";
+export { SurveyModel } from "@/domain/models/survey";
 export { AddSurveyRepository } from "@/data/protocols/db/survey/add-survey-repository";
 export { LoadSurveyByIdRepository } from "@/data/protocols/db/survey/load-survey-by-id-repository";
-export {
-  LoadSurveysRepository,
-  SurveyModel,
-} from "@/data/usecases/survey/load-surveys/db-load-surveys-protocols";
+export { LoadSurveysRepository } from "@/data/usecases/survey/load-surveys/db-load-surveys-protocols";

--- a/src/infra/db/mongodb/survey/survey-mongo-repository.ts
+++ b/src/infra/db/mongodb/survey/survey-mongo-repository.ts
@@ -15,7 +15,14 @@ export class SurveyMongoRepository
 {
   async add(surveyData: AddSurveyModel): Promise<void> {
     const surveyCollection = await MongoHelper.getCollection("surveys");
-    await surveyCollection.insertOne(surveyData);
+    const surveysAnswers = surveyData.answers.map((survey) => ({
+      ...survey,
+      answerId: MongoHelper.objectId(),
+    }));
+    await surveyCollection.insertOne({
+      ...surveyData,
+      answers: surveysAnswers,
+    });
   }
 
   async loadAll(): Promise<SurveyModel[]> {
@@ -26,7 +33,7 @@ export class SurveyMongoRepository
 
   async loadById(id: string): Promise<SurveyModel | null> {
     const surveyCollection = await MongoHelper.getCollection("surveys");
-    const surveyId = MongoHelper.toObjectId(id);
+    const surveyId = MongoHelper.objectId(id);
     const survey = await surveyCollection.findOne({
       _id: surveyId,
     });

--- a/src/main/factories/controllers/survey-result/save-survey-result/save-survey-result-validation-factory.spec.ts
+++ b/src/main/factories/controllers/survey-result/save-survey-result/save-survey-result-validation-factory.spec.ts
@@ -11,7 +11,7 @@ describe("SaveSurveyResultValidation Factory", () => {
   test("Should call ValidationComposite with all validations", () => {
     makeSaveSurveyResultValidation();
     const validations: Validation[] = [];
-    validations.push(new RequiredFieldValidation(["answer"]));
+    validations.push(new RequiredFieldValidation(["answerId"]));
     expect(ValidationComposite).toHaveBeenCalledWith(validations);
   });
 });

--- a/src/main/factories/controllers/survey-result/save-survey-result/save-survey-result-validation-factory.ts
+++ b/src/main/factories/controllers/survey-result/save-survey-result/save-survey-result-validation-factory.ts
@@ -6,6 +6,6 @@ import {
 
 export const makeSaveSurveyResultValidation = (): Validation => {
   const validations: Validation[] = [];
-  validations.push(new RequiredFieldValidation(["answer"]));
+  validations.push(new RequiredFieldValidation(["answerId"]));
   return new ValidationComposite(validations);
 };

--- a/src/main/routes/survey-result-routes.test.ts
+++ b/src/main/routes/survey-result-routes.test.ts
@@ -1,3 +1,4 @@
+import { SurveyModel } from "@/domain/models/survey";
 import { MongoHelper } from "@/infra/db/mongodb/helpers/mongodb-helper";
 import env from "@/main/config/env";
 import app from "@/main/config/app";
@@ -8,18 +9,27 @@ import request from "supertest";
 let surveyCollection: Collection;
 let accountCollection: Collection;
 
-const makeSurveyId = async (): Promise<string> => {
-  const survey = await surveyCollection.insertOne({
+const makeSurvey = async (): Promise<SurveyModel> => {
+  const insertedSurvey = await surveyCollection.insertOne({
     question: "Question",
     answers: [
       {
+        answerId: MongoHelper.objectId(),
         answer: "Answer 1",
+        image: "http://image-name.com",
+      },
+      {
+        answerId: MongoHelper.objectId(),
+        answer: "Answer 2",
         image: "http://image-name.com",
       },
     ],
     date: new Date(),
   });
-  return survey.insertedId.toString();
+  const survey = await surveyCollection.findOne({
+    _id: insertedSurvey.insertedId,
+  });
+  return MongoHelper.assign<SurveyModel>(survey);
 };
 
 const makeAccessToken = async (): Promise<string> => {
@@ -51,22 +61,24 @@ describe("SurveyResult Routes", () => {
   });
 
   describe("PUT /surveys/:surveyId/results", () => {
-    test("Should return 403 on save survey result without accessToken", async () =>
+    test("Should return 403 on save survey result without accessToken", async () => {
+      const survey = await makeSurvey();
       await request(app)
         .put("/api/surveys/any_id/results")
         .send({
-          answer: "Answer 1",
+          answerId: survey.answers[0].answerId.toString(),
         })
-        .expect(403));
+        .expect(403);
+    });
 
     test("Should return 200 on save survey result with accessToken", async () => {
-      const surveyId = await makeSurveyId();
+      const survey = await makeSurvey();
       const accessToken = await makeAccessToken();
       await request(app)
-        .put(`/api/surveys/${surveyId}/results`)
+        .put(`/api/surveys/${survey.id}/results`)
         .set("x-access-token", accessToken)
         .send({
-          answer: "Answer 1",
+          answerId: survey.answers[0].answerId.toString(),
         })
         .expect(200);
     });

--- a/src/main/routes/survey-routes.test.ts
+++ b/src/main/routes/survey-routes.test.ts
@@ -95,8 +95,8 @@ describe("Survey Routes", () => {
           question: "any_question",
           answers: [
             {
-              image: "any_image",
               answer: "any_answer",
+              image: "any_image",
             },
           ],
           date: new Date(),

--- a/src/presentation/controllers/survey-result/save-survey-result/save-survey-result-controller.spec.ts
+++ b/src/presentation/controllers/survey-result/save-survey-result/save-survey-result-controller.spec.ts
@@ -17,7 +17,7 @@ import MockDate from "mockdate";
 
 const makeFakeRequest = (): HttpRequest => ({
   body: {
-    answer: "any_answer",
+    answerId: "any_answer_id",
   },
   params: {
     surveyId: "any_survey_id",
@@ -30,6 +30,7 @@ const makeFakeSurvey = (): SurveyModel => ({
   question: "any_question",
   answers: [
     {
+      answerId: "any_answer_id",
       image: "any_image",
       answer: "any_answer",
     },
@@ -41,7 +42,7 @@ const makeFakeSurveyResult = (): SurveyResultModel => ({
   id: "valid_id",
   surveyId: "valid_survey_id",
   accountId: "valid_account_id",
-  answer: "valid_answer",
+  answerId: "valid_answer_id",
   date: new Date(),
 });
 
@@ -129,13 +130,13 @@ describe("SaveSurveyResult Controller", () => {
     const { sut } = makeSut();
     const httpResponse = await sut.handle({
       body: {
-        answer: "wrong_answer",
+        answerId: "wrong_answer_id",
       },
       params: {
         surveyId: "any_survey_id",
       },
     });
-    expect(httpResponse).toEqual(forbidden(new InvalidParamError("answer")));
+    expect(httpResponse).toEqual(forbidden(new InvalidParamError("answerId")));
   });
 
   test("Should return 500 if LoadSurveyById throws", async () => {
@@ -157,7 +158,7 @@ describe("SaveSurveyResult Controller", () => {
       surveyId: "any_survey_id",
       accountId: "any_account_id",
       date: new Date(),
-      answer: "any_answer",
+      answerId: "any_answer_id",
     });
   });
 

--- a/src/presentation/controllers/survey-result/save-survey-result/save-survey-result-controller.ts
+++ b/src/presentation/controllers/survey-result/save-survey-result/save-survey-result-controller.ts
@@ -27,13 +27,16 @@ export class SaveSurveyResultController implements Controller {
       }
 
       const surveyId = httpRequest.params?.surveyId;
-      const surveyAnswer = httpRequest.body?.answer;
+      const answerId = httpRequest.body?.answerId;
 
       const survey = await this.loadSurveyById.loadById(surveyId);
+
       if (survey) {
-        const answers = survey.answers.map(({ answer }) => answer.trim());
-        if (!answers.includes(surveyAnswer?.trim())) {
-          return forbidden(new InvalidParamError("answer"));
+        const findedAnswer = survey.answers.find(
+          (answer) => answer.answerId.toString() === answerId
+        );
+        if (!findedAnswer) {
+          return forbidden(new InvalidParamError("answerId"));
         }
       } else {
         return forbidden(new InvalidParamError("surveyId"));
@@ -41,7 +44,7 @@ export class SaveSurveyResultController implements Controller {
 
       const surveyResult = await this.saveSurveyResult.save({
         accountId: httpRequest.accountId,
-        answer: surveyAnswer,
+        answerId,
         surveyId,
         date: new Date(),
       });

--- a/src/presentation/controllers/survey/add-survey/add-survey-controller-protocols.ts
+++ b/src/presentation/controllers/survey/add-survey/add-survey-controller-protocols.ts
@@ -1,3 +1,4 @@
+export * from "@/domain/models/survey";
 export * from "@/domain/usecases/survey/add-survey";
 export * from "@/presentation/protocols";
 export * from "@/presentation/helpers/http/http-helper";

--- a/src/presentation/controllers/survey/load-surveys/load-surveys-controller.spec.ts
+++ b/src/presentation/controllers/survey/load-surveys/load-surveys-controller.spec.ts
@@ -8,12 +8,13 @@ import {
 } from "./load-surveys-controller-protocols";
 import MockDate from "mockdate";
 
-const makeFakeSurveys = (): SurveyModel[] => [
+const makeFakeLoadedSurveys = (): SurveyModel[] => [
   {
     id: "any_id",
     question: "any_question",
     answers: [
       {
+        answerId: "any_answer_id",
         image: "any_image",
         answer: "any_answer",
       },
@@ -25,6 +26,7 @@ const makeFakeSurveys = (): SurveyModel[] => [
     question: "other_question",
     answers: [
       {
+        answerId: "other_answer_id",
         image: "other_image",
         answer: "other_answer",
       },
@@ -36,7 +38,7 @@ const makeFakeSurveys = (): SurveyModel[] => [
 const makeLoadSurveys = (): LoadSurveys => {
   class LoadSurveysStub implements LoadSurveys {
     async load(): Promise<SurveyModel[]> {
-      return new Promise((resolve) => resolve(makeFakeSurveys()));
+      return new Promise((resolve) => resolve(makeFakeLoadedSurveys()));
     }
   }
   return new LoadSurveysStub();
@@ -68,7 +70,7 @@ describe("LoadSurveys Controller", () => {
   test("Should return 200 on success", async () => {
     const { sut } = makeSut();
     const httpResponse = await sut.handle({});
-    expect(httpResponse).toEqual(ok(makeFakeSurveys()));
+    expect(httpResponse).toEqual(ok(makeFakeLoadedSurveys()));
   });
 
   test("Should return 204 if LoadSurveys returns empty", async () => {


### PR DESCRIPTION
### Add id to identify each answers a survey answer

Currently when surveys are created, their responses do not have a unique identifier (`id`). This is a problem, because when we are going to answer these surveys, we have to send the `string` that corresponds to the answer of this survey to the API, that is, the answer is the identifier in this case. This is wrong as it is vulnerable to failure. We need a solution that will revolve around creating survey controllers and adding response.